### PR TITLE
OSU CAS User Migration

### DIFF
--- a/modules/osu_user_accounts/migrations/upgrade_d7_cas_user.yml
+++ b/modules/osu_user_accounts/migrations/upgrade_d7_cas_user.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies: { }
+id: upgrade_d7_cas_user
+class: Drupal\migrate\Plugin\Migration
+field_plugin_method: null
+cck_plugin_method: null
+migration_tags:
+  - 'Drupal 7 OG'
+migration_group: insert_users
+label: OSU CAS User
+source:
+  plugin: d7_cas_user
+process:
+  uid:
+    - plugin: migration_lookup
+      migration: upgrade_d7_users_with_roles
+      no_stub: true
+      source: uid
+    - plugin: skip_on_empty
+      method: row
+      message: 'uid is missing'
+  provider:
+    - plugin: default_value
+      default_value: cas
+  authname: cas_name
+destination:
+  plugin: authmap
+migration_dependencies:
+  required:
+    - upgrade_d7_users_with_roles


### PR DESCRIPTION
Migrate mapping to filter only our users whom have been migrated to import their CAS connection.
Needs #1 first to be merged in.