### PR TITLE
Add dependency on osu_migrations_files.

### DIFF
--- a/modules/osu_migrations_media/osu_migrations_media.info.yml
+++ b/modules/osu_migrations_media/osu_migrations_media.info.yml
@@ -6,3 +6,4 @@ core_version_requirement: ^9 || ^10
 
 dependencies:
   - osu_migrations:osu_migrations
+  - osu_migrations_files:osu_migrations_files


### PR DESCRIPTION
Simple one to add dependency on **osu_migrations_files**
This assumes that to run your media migrations, one should have run their files migration first to reference.