### PR TITLE
Remove fields from form display and hide them

### DIFF
--- a/modules/paragraphs_to_layout_builder/config/install/core.entity_form_display.block_content.paragraph_block.default.yml
+++ b/modules/paragraphs_to_layout_builder/config/install/core.entity_form_display.block_content.paragraph_block.default.yml
@@ -28,22 +28,6 @@ content:
       placeholder: ''
       show_summary: false
     third_party_settings: {  }
-  field_eb_background_fc:
-    type: string_textfield
-    weight: 28
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_styles:
-    type: text_textfield
-    weight: 2
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
   info:
     type: string_textfield
     weight: 0
@@ -52,4 +36,6 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_eb_background_fc: true
+  field_styles: true


### PR DESCRIPTION
The commit removes the 'field_eb_background_fc' and 'field_styles' from the form display configuration of Paragraph Block within the Paragraphs to Layout Builder module. These fields' visibility in the module has been set to hidden, ensuring they do not appear on the form display.