### PR TITLE
Add migration configurations for LPI site

### DIFF
--- a/site_migrations/osu_migrations_lpi/README.md
+++ b/site_migrations/osu_migrations_lpi/README.md
@@ -1,0 +1,12 @@
+# LPI Migrations
+NHR Conditions (Machine name: hdi_topics)
+- Groups
+- Fields
+  - title
+  - field_intro
+  - field_authors_and_reviewers
+  - field_relevan_external_links
+  - field_related_conditions
+  - field_infographic
+  - field_infographic_pdf
+  - field_hdi_printer_friendly_pdf

--- a/site_migrations/osu_migrations_lpi/migrations/upgrade_d7_hdi_topics.yml
+++ b/site_migrations/osu_migrations_lpi/migrations/upgrade_d7_hdi_topics.yml
@@ -1,0 +1,116 @@
+langcode: en
+status: true
+dependencies: { }
+id: upgrade_d7_hdi_topics
+migration_group: LPI
+migration_tags:
+  - Drupal 7
+  - LPI
+  - OSU Content
+  - OSU
+source:
+  plugin: d7_node
+  node_type: hdi_topics
+process:
+  nid: nid
+  title: title
+  status: status
+  created: created
+  changed: changed
+  comment: comment
+  promote: promote
+  sticky: sticky
+  path/pathauto:
+    plugin: default_value
+    default_value: 0
+  uid:
+    - plugin: migration_lookup
+      migration: upgrade_d7_users_with_roles
+      source: node_uid
+      no_stub: true
+    - plugin: default_value
+      default_value: 1
+  body:
+    - plugin: sub_process
+      source: field_intro
+      process:
+        value:
+          plugin: osu_media_wysiwyg_filter
+          source: value
+        format:
+          plugin: default_value
+          default_value: 'full_html'
+  field_authors_and_reviewers:
+    - plugin: sub_process
+      source: field_authors_and_reviewers
+      process:
+        value:
+          plugin: osu_media_wysiwyg_filter
+          source: value
+        format:
+          plugin: default_value
+          default_value: 'full_html'
+  field_relevant_external_links:
+    - plugin: sub_process
+      source: field_relevant_external_links
+      process:
+        value:
+          plugin: osu_media_wysiwyg_filter
+          source: value
+        format:
+          plugin: default_value
+          default_value: 'full_html'
+  field_related_conditions:
+    - plugin: sub_process
+      source: field_related_conditions
+      process:
+        value:
+          plugin: osu_media_wysiwyg_filter
+          source: value
+        format:
+          plugin: default_value
+          default_value: 'full_html'
+  field_infographic:
+    plugin: sub_process
+    source: field_infographic
+    process:
+      target_id:
+        - plugin: migration_lookup
+          migration: upgrade_d7_media_images
+          source: fid
+      alt: alt
+  field_infographic_pdf:
+    plugin: sub_process
+    source: field_infographic_pdf
+    process:
+      target_id:
+        plugin: migration_lookup
+        migration: upgrade_d7_media_documents
+        source: fid
+      description: description
+  field_hdi_printer_friendly_pdf:
+    plugin: sub_process
+    source: field_hdi_printer_friendly_pdf
+    process:
+      target_id:
+        plugin: migration_lookup
+        migration: upgrade_d7_media_documents
+        source: fid
+      description: description
+  type:
+    plugin: default_value
+    default_value: hdi_topics
+destination:
+  plugin: 'entity:node'
+migration_dependencies:
+  required:
+    - upgrade_d7_files
+    - upgrade_d7_media_images
+    - upgrade_d7_users_with_roles
+    - upgrade_d7_taxonomy_terms
+  optional:
+    - upgrade_d7_media_audio
+    - upgrade_d7_media_documents
+    - upgrade_d7_media_local_video
+    - upgrade_d7_media_kaltura
+    - upgrade_d7_media_remote_video

--- a/site_migrations/osu_migrations_lpi/migrations/upgrade_d7_hdi_topics_group_content.yml
+++ b/site_migrations/osu_migrations_lpi/migrations/upgrade_d7_hdi_topics_group_content.yml
@@ -1,0 +1,43 @@
+langcode: en
+status: true
+dependencies: { }
+id: upgrade_d7_hdi_topics_group_content
+migration_tags:
+  - Drupal 7 OG
+  - LPI
+  - OSU Groups Content
+  - OSU Groups
+  - OSU
+migration_group: LPI
+label: 'Migrate NHR Conditions content from d7 into Group content'
+source:
+  plugin: d7_og_membership_content
+  node_type:
+    - hdi_topics
+process:
+  label: etid
+  type:
+    plugin: default_value
+    default_value: group_content_type_b9f64f6585dc7
+  gid:
+    - plugin: migration_lookup
+      migration: upgrade_d7_node_og_group
+      no_stub: true
+      source: gid
+    - plugin: skip_on_empty
+      method: row
+      message: 'gid is missing'
+  entity_id:
+    - plugin: migration_lookup
+      migration: upgrade_d7_hdi_topics
+      no_stub: true
+      source: etid
+    - plugin: skip_on_empty
+      method: row
+      message: 'node missing.'
+destination:
+  plugin: 'entity:group_content'
+migration_dependencies:
+  required:
+    - upgrade_d7_node_og_group
+    - upgrade_d7_hdi_topics

--- a/site_migrations/osu_migrations_lpi/osu_migrations_lpi.info.yml
+++ b/site_migrations/osu_migrations_lpi/osu_migrations_lpi.info.yml
@@ -1,0 +1,9 @@
+name: OSU Migrations - Linus Pauling Institute
+type: module
+description: Contains migrations specifically for the Linus Pauling Institute Site.
+package: OSU Migrations - Sites
+core_version_requirement: ^9 || ^10
+
+dependencies:
+  - drupal:osu_migrations
+  - osu_migrations:og_to_group


### PR DESCRIPTION
This commit adds three new migration configurations for the Linus Pauling Institute site. This includes the migration of 'hdi_topics' content from Drupal 7 into Group content as well as a README file detailing the migration