### PR TITLE
Add migrations for Senate event and committee group content

### DIFF
--- a/site_migrations/osu_migrations_senate/README.md
+++ b/site_migrations/osu_migrations_senate/README.md
@@ -1,0 +1,30 @@
+# Template for site-specific migrations
+
+Copy this directory and rename `template` with a short name of the site.
+
+Migrations specific to that site will be included here. Any custom Source/Process plugins can be created and referenced
+here.
+
+## Checklist
+
+It is recommended to create lists here for the site and update them during the migration process.
+
+### Example List
+
+#### Node types with Paragraph fields
+
+Listing the dependencies of the type can help you understand what needs to be configured for the migration.
+
+- [ ] New type
+    - Uses Paragraphs
+    - Uses Image
+    - Uses File Uploads
+- [x] Done type
+
+#### Group Types
+
+If a node needs to be included in a Group or be Group aware a custom migration is needed for those types other than
+Basic page and Parent Unit
+
+- [ ] Program
+- [ ] Degrees

--- a/site_migrations/osu_migrations_senate/migrations/upgrade_d7_senate_committee_group_content.yml
+++ b/site_migrations/osu_migrations_senate/migrations/upgrade_d7_senate_committee_group_content.yml
@@ -1,0 +1,43 @@
+langcode: en
+status: true
+dependencies: { }
+id: upgrade_d7_senate_committee_group_content
+migration_tags:
+  - Drupal 7 OG
+  - OSU Groups Content
+  - OSU Groups
+  - OSU
+  - Senate
+migration_group: osu_groups
+label: 'Migrate Page content from d7 into Group content'
+source:
+  plugin: d7_og_membership_content
+  node_type:
+    - committee
+process:
+  label: etid
+  type:
+    plugin: default_value
+    default_value: basic_group-group_node-committee
+  gid:
+    - plugin: migration_lookup
+      migration: upgrade_d7_node_og_group
+      no_stub: true
+      source: gid
+    - plugin: skip_on_empty
+      method: row
+      message: 'gid is missing'
+  entity_id:
+    - plugin: migration_lookup
+      migration: upgrade_d7_node
+      no_stub: true
+      source: etid
+    - plugin: skip_on_empty
+      method: row
+      message: 'node missing.'
+destination:
+  plugin: 'entity:group_content'
+migration_dependencies:
+  required:
+    - upgrade_d7_node_og_group
+    - upgrade_d7_node

--- a/site_migrations/osu_migrations_senate/migrations/upgrade_d7_senate_event_group_content.yml
+++ b/site_migrations/osu_migrations_senate/migrations/upgrade_d7_senate_event_group_content.yml
@@ -1,0 +1,43 @@
+langcode: en
+status: true
+dependencies: { }
+id: upgrade_d7_senate_event_group_content
+migration_tags:
+  - Drupal 7 OG
+  - OSU Groups Content
+  - OSU Groups
+  - OSU
+  - Senate
+migration_group: osu_groups
+label: 'Migrate Page content from d7 into Group content'
+source:
+  plugin: d7_og_membership_content
+  node_type:
+    - event
+process:
+  label: etid
+  type:
+    plugin: default_value
+    default_value: basic_group-group_node-event
+  gid:
+    - plugin: migration_lookup
+      migration: upgrade_d7_node_og_group
+      no_stub: true
+      source: gid
+    - plugin: skip_on_empty
+      method: row
+      message: 'gid is missing'
+  entity_id:
+    - plugin: migration_lookup
+      migration: upgrade_d7_node
+      no_stub: true
+      source: etid
+    - plugin: skip_on_empty
+      method: row
+      message: 'node missing.'
+destination:
+  plugin: 'entity:group_content'
+migration_dependencies:
+  required:
+    - upgrade_d7_node_og_group
+    - upgrade_d7_node

--- a/site_migrations/osu_migrations_senate/osu_migrations_senate.info.yml
+++ b/site_migrations/osu_migrations_senate/osu_migrations_senate.info.yml
@@ -1,0 +1,8 @@
+name: OSU Migrations - Faculty Senate
+type: module
+description: Contains migrations for the Faculty Senate site.
+package: OSU Migrations - Sites
+core_version_requirement: ^10 || ^11
+
+dependencies:
+  - osu_migrations:osu_migrations


### PR DESCRIPTION
Introduced new migration configurations for Drupal 7 to Drupal 10 group content specific to Senate events and committees. Added a README template and metadata files to organize and document the migration process.