### PR TITLE
Add support for handling and migrating missing file references

### DIFF
--- a/modules/paragraphs_to_layout_builder/config/install/migrate_plus.migration.book_to_page.yml
+++ b/modules/paragraphs_to_layout_builder/config/install/migrate_plus.migration.book_to_page.yml
@@ -35,8 +35,9 @@ process:
       source: body
       process:
         value:
-          plugin: osu_media_wysiwyg_filter
-          source: value
+          - plugin: osu_wysiwyg_filter_missing_files
+            source: value
+          - plugin: osu_media_wysiwyg_filter
         summary: summary
         format:
           plugin: default_value

--- a/modules/paragraphs_to_layout_builder/config/install/migrate_plus.migration.page_to_page.yml
+++ b/modules/paragraphs_to_layout_builder/config/install/migrate_plus.migration.page_to_page.yml
@@ -35,8 +35,9 @@ process:
       source: body
       process:
         value:
-          plugin: osu_media_wysiwyg_filter
-          source: value
+          - plugin: osu_wysiwyg_filter_missing_files
+            source: value
+          - plugin: osu_media_wysiwyg_filter
         summary: summary
         format:
           plugin: default_value

--- a/osu_migrations.services.yml
+++ b/osu_migrations.services.yml
@@ -6,4 +6,8 @@ services:
 
   osu_migrations.osu_media_embed:
     class: Drupal\osu_migrations\OsuMediaEmbed
-    arguments: ['@migrate.lookup', '@entity_type.manager']
+    arguments: [ '@migrate.lookup', '@entity_type.manager' ]
+
+  osu_migrations.osu_migrate_missing_files:
+    class: Drupal\osu_migrations\OsuMigrateMissingFiles
+    arguments: [ '@logger.factory', '@entity_type.manager', '@file_system' ]

--- a/src/OsuMigrateMissingFiles.php
+++ b/src/OsuMigrateMissingFiles.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Drupal\osu_migrations;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileExists;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\file\Entity\File;
+use Drupal\media\Entity\Media;
+use Drupal\migrate\MigrateLookupInterface;
+
+/**
+ * Class responsible for migrating missing files referenced in text content.
+ *
+ * This class scans text content for references to local files and attempts to
+ * copy them if they are missing. Files that are found are imported and
+ * managed as Drupal entities.
+ */
+class OsuMigrateMissingFiles {
+
+  /**
+   * The Migrate lookup interface.
+   *
+   * @var \Drupal\migrate\MigrateLookupInterface
+   */
+  private MigrateLookupInterface $lookup;
+
+  /**
+   * The Entity type Manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  private EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * The File system Interface.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  private FileSystemInterface $fileSystem;
+
+  /**
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  private LoggerChannelFactoryInterface $logger;
+
+  /**
+   * Constructor method.
+   *
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger
+   *   The logger channel factory interface.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager interface.
+   * @param \Drupal\Core\File\FileSystemInterface $file_system
+   *   The file system interface.
+   */
+  public function __construct(LoggerChannelFactoryInterface $logger, EntityTypeManagerInterface $entity_type_manager, FileSystemInterface $file_system) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->fileSystem = $file_system;
+    $this->logger = $logger;
+  }
+
+  /**
+   * Processes missing files referenced in the given value and attempts to
+   * migrate them if necessary.
+   *
+   * This method scans the provided text for links to local files, including
+   * images, and checks if they have already been migrated. If the files are
+   * not found in the system, it attempts to copy the file and add it as a
+   * managed file.
+   *
+   * @param string $value
+   *   The text to scan for references to local files.
+   *
+   * @return void
+   *   No return value.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function copyMissingFiles(string $value): void {
+    // Create two named capture groups for the relative path and the file URI.
+    $pattern = '/(href|src)=\s*["\'](?<relativePath>\/sites\/[a-zA-Z0-9\.]*\/files\/(?<uri>.*))["\']/isU';
+    // Scan the text for matches and store them in an associative array.
+    preg_match_all($pattern, $value, $matches);
+    // If we found any matches, attempt to copy and import the files.
+    if ($matches && count($matches['uri']) > 0) {
+      foreach ($matches['uri'] as $key => $fileUri) {
+        $publicUri = "public://{$fileUri}";
+        $foundFiles = $this->entityTypeManager->getStorage('file')
+          ->loadByProperties(['uri' => $publicUri]);
+        if ($foundFiles && count($foundFiles) > 0) {
+          continue;
+        }
+        else {
+          $this->copyAndImportFile($matches['relativePath'][$key], $matches['uri'][$key]);
+        }
+      }
+    }
+  }
+
+  /**
+   * Moves a file to a specified directory and imports it as a managed file.
+   *
+   * @param string $relativePath
+   *   The relative path of the file to be moved, based on the Drupal root.
+   * @param string $fileUri
+   *   The target file URI where the file should be moved to within the public
+   *   directory.
+   *
+   * @return void
+   *   This method does not return a value.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  private function copyAndImportFile(string $relativePath, string $fileUri): void {
+    // Ensure Destination directory exists.
+    $containerDir = dirname($fileUri);
+    if ($containerDir === '.') {
+      $destinationDirUri = 'public://';
+    }
+    else {
+      $destinationDirUri = "public://{$containerDir}";
+    }
+    $this->fileSystem->prepareDirectory($destinationDirUri, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS);
+    $copiedFileUri = $this->fileSystem->copy(DRUPAL_ROOT . $relativePath, $destinationDirUri, FileExists::Replace);
+    if (!$copiedFileUri) {
+      $this->logger->get('osu_migrations')
+        ->warning("Could not copy file {$relativePath}");
+      return;
+    }
+    $copiedFileObject = File::create(['uri' => $copiedFileUri, 'status' => 1]);
+    $copiedFileObject->setPermanent();
+    $copiedFileObject->save();
+    $mimeType = $copiedFileObject->getMimeType();
+    if (str_starts_with($mimeType, 'image/')) {
+      Media::create([
+        'bundle' => 'image',
+        'field_media_image' => $copiedFileObject,
+      ])
+        ->save();
+    }
+    elseif (str_starts_with($mimeType, 'video/')) {
+      // Create local video.
+      Media::create([
+        'bundle' => 'local_video',
+        'field_media_file' => $copiedFileObject,
+      ])
+        ->save();
+    }
+    elseif (str_starts_with($mimeType, 'application/') || str_starts_with($mimeType, 'text/')) {
+      // Create Document.
+      Media::create([
+        'bundle' => 'file',
+        'field_media_file' => $copiedFileObject,
+      ])
+        ->save();
+    }
+  }
+
+}

--- a/src/Plugin/migrate/process/OsuWysiwygFilterMissingFiles.php
+++ b/src/Plugin/migrate/process/OsuWysiwygFilterMissingFiles.php
@@ -3,6 +3,7 @@
 namespace Drupal\osu_migrations\Plugin\migrate\process;
 
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\migrate\Attribute\MigrateProcess;
 use Drupal\migrate\MigrateExecutableInterface;
 use Drupal\migrate\ProcessPluginBase;
 use Drupal\migrate\Row;
@@ -11,11 +12,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Process Plugin to transform Drupal 7 embed to Drupal 9.
- *
- * @MigrateProcessPlugin(
- *   id = "osu_wysiwyg_filter_missing_files"
- * )
  */
+#[MigrateProcess(
+  id: 'osu_wysiwyg_filter_missing_files'
+)]
 class OsuWysiwygFilterMissingFiles extends ProcessPluginBase implements ContainerFactoryPluginInterface {
 
   /**

--- a/src/Plugin/migrate/process/OsuWysiwygFilterMissingFiles.php
+++ b/src/Plugin/migrate/process/OsuWysiwygFilterMissingFiles.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Drupal\osu_migrations\Plugin\migrate\process;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+use Drupal\osu_migrations\OsuMigrateMissingFiles;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Process Plugin to transform Drupal 7 embed to Drupal 9.
+ *
+ * @MigrateProcessPlugin(
+ *   id = "osu_wysiwyg_filter_missing_files"
+ * )
+ */
+class OsuWysiwygFilterMissingFiles extends ProcessPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * @var \Drupal\osu_migrations\OsuMigrateMissingFiles
+   */
+  private OsuMigrateMissingFiles $osuMigrateMissingFiles;
+
+  /**
+   * Constructs a new instance of the class.
+   *
+   * @param array $configuration
+   *   An array of configuration settings.
+   * @param string $plugin_id
+   *   The plugin ID.
+   * @param mixed $plugin_definition
+   *   The plugin definition.
+   * @param \Drupal\osu_migrations\OsuMigrateMissingFiles $osuMigrateMissingFiles
+   *   An instance of the OsuMigrateMissingFiles service.
+   *
+   * @return void
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, OsuMigrateMissingFiles $osuMigrateMissingFiles) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->osuMigrateMissingFiles = $osuMigrateMissingFiles;
+  }
+
+  /**
+   * Creates a new instance of the class.
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   The container interface for dependency injection.
+   * @param array $configuration
+   *   An array of configuration settings.
+   * @param string $plugin_id
+   *   The plugin ID.
+   * @param mixed $plugin_definition
+   *   The plugin definition.
+   *
+   * @return static
+   *   A new instance of the class.
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('osu_migrations.osu_migrate_missing_files'),
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    $value_is_array = is_array($value);
+    $text = (string) ($value_is_array ? $value['value'] : $value);
+    $this->osuMigrateMissingFiles->copyMissingFiles($text);
+
+    return $value;
+  }
+
+}


### PR DESCRIPTION
Introduced `OsuMigrateMissingFiles` service to detect and migrate missing file references in WYSIWYG content during Drupal 7 to Drupal 9/10 migrations. Added the `osu_wysiwyg_filter_missing_files` process plugin and updated relevant migration configurations to include this plugin alongside existing WYSIWYG filters. Updated services definition for dependency injection.